### PR TITLE
Fixes issue of not detecting multi-digit numeric literals

### DIFF
--- a/syntax/bosatsu.vim
+++ b/syntax/bosatsu.vim
@@ -16,7 +16,7 @@ syn keyword bosatsuKeywords
   \ struct
 
 syn match bosatsuComment "#.*$"
-syntax match bosatsuNumber "\v<\d[\d_]*>"
+syntax match bosatsuNumber "\v<\d(\d|_)*>"
 
 syntax region bosatsuString start=/"/ skip=/\\"/ end=/"/
 syntax region bosatsuString start=/'/ skip=/\\'/ end=/'/


### PR DESCRIPTION
`\v<\d[\d_]*>` will not match `10` but `\v<\d(\d|_)*>` will (I've not actually tested this code beyond doing searches in vim)